### PR TITLE
Remove service dependency

### DIFF
--- a/app/admin/admin.controllers.js
+++ b/app/admin/admin.controllers.js
@@ -11,9 +11,7 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
     
     
     $scope.UGList = adminUGFactory.get_UG.query(function(response) {
-        console.log(response);
         adminUGFactory.get_UG_set.query(function(response){
-            console.log(response);
             if (response.value) {
                 $scope.userAdminGroup = response.value;
                 $scope.UGList.userGroups.forEach(function(ug) {
@@ -34,11 +32,9 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
     });
 
     $scope.OUGSList = adminOUGSFactory.get_OUGS.query(function(response) {
-        console.log(response);
         adminOUGSFactory.get_OUGS_set.query(function(response){
-            console.log(response);
             if (response.value) {
-                $scope.serviceSetUID = response.value; //BtFXTpKRl6n//
+                $scope.serviceSetUID = response.value;
                 $scope.OUGSList.organisationUnitGroupSets.forEach(function(ougs) {
                     if (ougs.id == response.object.id) {
                         $scope.selectedOUGS = ougs;      
@@ -99,11 +95,9 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
     });
     
     $scope.submitUG = function() {
-        console.log($scope.selectedUG);
         var payload = '{"value":"' + $scope.selectedUG.name + '", "object":'+ JSON.stringify($scope.selectedUG) +'}';
         if ($scope.userAdminGroup) {
             adminUGFactory.upd_UG.query(payload,function(response){
-                console.log(response);
                 if (response) {
                     $scope.userAdminGroup = $scope.selectedUG.name;    
                     $('#divUG').removeClass('alert-warning');
@@ -113,7 +107,6 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
             });
         }else{    
             adminUGFactory.set_UG.query(payload,function(response){
-                console.log(response);
                 if (response) {
                     $scope.userAdminGroup = $scope.selectedUG.name;    
                     $('#divUG').removeClass('alert-warning');
@@ -126,11 +119,9 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
     };
     
     $scope.submitOUGS = function() {
-        console.log($scope.selectedOUGS);
         var payload = '{"value":"' + $scope.selectedOUGS.id + '", "object":'+ JSON.stringify($scope.selectedOUGS) +'}';
         if ($scope.serviceSetUID) {
             adminOUGSFactory.upd_OUGS.query(payload,function(response){
-                console.log(response);
                 if (response) {
                     $scope.serviceSetUID = $scope.selectedOUGS.id;   
                     $('#divOUGS').removeClass('alert-warning');
@@ -140,7 +131,6 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
             });
         }else{
             adminOUGSFactory.set_OUGS.query(payload,function(response){
-                console.log(response);
                 if (response) {
                     $scope.serviceSetUID = $scope.selectedOUGS.id;    
                     $('#divOUGS').removeClass('alert-warning');
@@ -153,7 +143,6 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
     };
     
     adminAFactory.get(function(result) {
-        console.log(result);
         var test = false;
         result.attributes.forEach(function(attr) {
             if (attr.name == "serviceCode" && attr.dataSetAttribute && attr.indicatorGroupAttribute) {
@@ -177,17 +166,14 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
     }
     
     $scope.submitDS = function() {
-        console.log($scope.selectedDS);
         adminDSFactory.get_DS_set.query($scope.selectedDS).$promise.then(function(response1){
             return adminDSFactory.upd_DS.query($scope.selectedDS,function(response2){
-                console.log(response2);
                 if (response2) {
                     $scope.blacklist_datasets = $scope.selectedDS;    
                 }
             });
         }, function() {   
             return adminDSFactory.set_DS.query($scope.selectedDS,function(response2){
-                console.log(response2);
                 if (response2) {
                     $scope.blacklist_datasets = $scope.selectedDS;
                 }
@@ -202,17 +188,14 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
     }
     
     $scope.submitIG = function() {
-        console.log($scope.selectedIG);
         adminIGFactory.get_IG_set.query($scope.selectedIG).$promise.then(function(response1){
             return adminIGFactory.upd_IG.query($scope.selectedIG,function(response2){
-                console.log(response2);
                 if (response2) {
                     $scope.blacklist_indicatorgroups = $scope.selectedIG;    
                 }
             });
         }, function() {  
             return adminIGFactory.set_IG.query($scope.selectedIG,function(response){
-                console.log(response);
                 if (response) {
                     $scope.blacklist_indicatorgroups = $scope.selectedIG;    
                 }

--- a/app/admin/admin.controllers.js
+++ b/app/admin/admin.controllers.js
@@ -38,7 +38,7 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
         adminOUGSFactory.get_OUGS_set.query(function(response){
             console.log(response);
             if (response.value) {
-                $scope.ougsUID = response.value; //BtFXTpKRl6n//
+                $scope.serviceSetUID = response.value; //BtFXTpKRl6n//
                 $scope.OUGSList.organisationUnitGroupSets.forEach(function(ougs) {
                     if (ougs.id == response.object.id) {
                         $scope.selectedOUGS = ougs;      
@@ -49,7 +49,7 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
                 $('#divOUGS').addClass('alert-success');
                 
                 adminOUGFactory.get({
-                    ougsUID: $scope.ougsUID
+                    ougsUID: $scope.serviceSetUID
                 }, function(result) {
                     var test = true;
                     if(result.organisationUnitGroups.length > 0){
@@ -128,11 +128,11 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
     $scope.submitOUGS = function() {
         console.log($scope.selectedOUGS);
         var payload = '{"value":"' + $scope.selectedOUGS.id + '", "object":'+ JSON.stringify($scope.selectedOUGS) +'}';
-        if ($scope.ougsUID) {
+        if ($scope.serviceSetUID) {
             adminOUGSFactory.upd_OUGS.query(payload,function(response){
                 console.log(response);
                 if (response) {
-                    $scope.ougsUID = $scope.selectedOUGS.id;   
+                    $scope.serviceSetUID = $scope.selectedOUGS.id;   
                     $('#divOUGS').removeClass('alert-warning');
                     $('#divOUGS').removeClass('alert-danger');
                     $('#divOUGS').addClass('alert-success');
@@ -142,7 +142,7 @@ adminModule.controller('adminMainController', ['$scope', '$translate', 'adminOUG
             adminOUGSFactory.set_OUGS.query(payload,function(response){
                 console.log(response);
                 if (response) {
-                    $scope.ougsUID = $scope.selectedOUGS.id;    
+                    $scope.serviceSetUID = $scope.selectedOUGS.id;    
                     $('#divOUGS').removeClass('alert-warning');
                     $('#divOUGS').removeClass('alert-danger');
                     $('#divOUGS').addClass('alert-success');

--- a/app/app.config.js
+++ b/app/app.config.js
@@ -23,7 +23,7 @@ var appModule = angular.module('appModule', ['ui.router', 'd2Menu', 'ngSanitize'
  */
 appModule.config(['$stateProvider', '$urlRouterProvider', '$translateProvider', function($stateProvider, $urlRouterProvider, $translateProvider) {
 
-    $urlRouterProvider.otherwise("/dossiers")
+    $urlRouterProvider.otherwise("/search")
 
     $stateProvider
         .state('dossiers', {

--- a/app/app.controllers.js
+++ b/app/app.controllers.js
@@ -11,10 +11,6 @@
  */
 appModule.controller('appSharedController', ['$scope', '$translate', '$state', '$location', '$stateParams', '$http', '$window', function($scope, $translate, $state, $location, $anchorScroll, $stateParams, $http, $window) {
 
-    
-    //$scope.serviceSetUID = 'g7k6NQmqJY2'; //BtFXTpKRl6n//
-    //$scope.userAdminGroup = 'Administrators';    
-
     this.$route = $state;
     this.$location = $location;
     this.$routeParams = $stateParams;

--- a/app/app.controllers.js
+++ b/app/app.controllers.js
@@ -12,7 +12,7 @@
 appModule.controller('appSharedController', ['$scope', '$translate', '$state', '$location', '$stateParams', '$http', '$window', function($scope, $translate, $state, $location, $anchorScroll, $stateParams, $http, $window) {
 
     
-    //$scope.ougsUID = 'g7k6NQmqJY2'; //BtFXTpKRl6n//
+    //$scope.serviceSetUID = 'g7k6NQmqJY2'; //BtFXTpKRl6n//
     //$scope.userAdminGroup = 'Administrators';    
 
     this.$route = $state;
@@ -50,8 +50,8 @@ appModule.controller('appSharedController', ['$scope', '$translate', '$state', '
         async: false
     }).success(function(servicelist) {
         servicelist = jQuery.parseJSON(servicelist);
-        $scope.ougsUID = servicelist.value;
-        if ($scope.ougsUID) {
+        $scope.serviceSetUID = servicelist.value;
+        if ($scope.serviceSetUID) {
             console.log('appModule: List of services taken from organisationUnitGroupSet: ' + servicelist.value);
         }else{
             console.log('appModule: organisationUnitGroupSet to take the list of services has not been defined yet, go to the admin panel!');

--- a/app/dossiers/dossiers.controllers.js
+++ b/app/dossiers/dossiers.controllers.js
@@ -47,7 +47,7 @@ dossiersModule.controller('dossiersMainController', ['$scope', '$translate', '$a
      *  @scope dossiersMainController
      */
     $scope.services = dossiersServicesFactory.get({
-        ougsUID: $scope.ougsUID
+        ougsUID: $scope.serviceSetUID
     }, function() {
         endLoadingState();
     });

--- a/app/search/search.controllers.js
+++ b/app/search/search.controllers.js
@@ -7,22 +7,29 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
 
     $('#search').tab('show');
 
-    searchAllFactory.get_organisationUnitGroupSets.query({
-        ougsUID: $scope.serviceSetUID
-    }, function(response){
-        //console.log('get_organisationUnitGroupSets', response);
-        var temp = {};
-        response.organisationUnitGroups.forEach(function(serv) {
-            temp[serv.code.split('_')[2]] = {
-                service_id: serv.id,
-                service_code: serv.code,
-                service_name: serv.displayName
-            };
+    
+    if ($scope.serviceSetUID) {
+        console.log("searchModule: Service set defined " + $scope.serviceSetUID);
+        searchAllFactory.get_organisationUnitGroupSets.query({
+            ougsUID: $scope.serviceSetUID
+        }, function(response){
+            var temp = {};
+            response.organisationUnitGroups.forEach(function(serv) {
+                temp[serv.code.split('_')[2]] = {
+                    service_id: serv.id,
+                    service_code: serv.code,
+                    service_name: serv.displayName
+                };
+            });
+            //console.log('get_organisationUnitGroupSets refactored', temp);
+            $scope.servicesList = temp;
+            load_table();
         });
-        //console.log('get_organisationUnitGroupSets refactored', temp);
-        $scope.servicesList = temp;
-    });
-
+    } else {
+        console.log("searchModule: Service set is not defined");
+        load_table();
+    }
+    
     var concatObjects = function(tablesList) {
         var temp = [];
         tablesList.forEach(function(table) {
@@ -215,7 +222,7 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
             });
     };
 
-    $scope.$watch('servicesList', function(){
+    function load_table() {
 
         var start = new Date();
         //console.log('servicesList available?', $scope.servicesList);
@@ -365,7 +372,7 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
                 console.log("Loading time of search table: " + (Date.now() - start) + " milliseconds.");
             });
         }
-    });
+    }
 
     $scope.exportToExcel = function(tableId){ // ex: '#my-table'
         var exportHref = ExcelFactory.tableToExcel(tableId,'hmis_table');
@@ -374,4 +381,4 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
         a.download = 'hmis_table.xls';
         a.click();
     }
-}]);
+}])

--- a/app/search/search.controllers.js
+++ b/app/search/search.controllers.js
@@ -8,7 +8,7 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
     $('#search').tab('show');
 
     searchAllFactory.get_organisationUnitGroupSets.query({
-        ougsUID: $scope.ougsUID
+        ougsUID: $scope.serviceSetUID
     }, function(response){
         //console.log('get_organisationUnitGroupSets', response);
         var temp = {};

--- a/app/search/search.controllers.js
+++ b/app/search/search.controllers.js
@@ -226,7 +226,8 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
 
         var start = new Date();
         //console.log('servicesList available?', $scope.servicesList);
-        if ($scope.servicesList) {
+        // if ($scope.servicesList) {
+        if (true) {
 
             var temp = {};
             var categoryOptionCombosTemp = {};
@@ -248,7 +249,7 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
                         };
 
                         obj.dataSetElements.forEach(function(grp) {
-                            if(grp.dataSet.attributeValues.length > 0 && grp.dataSet.attributeValues[0].value){
+                            if($scope.servicesList && grp.dataSet.attributeValues.length > 0 && grp.dataSet.attributeValues[0].value){
                                 var servicesCode = grp.dataSet.attributeValues[0].value.split('_');
                                 servicesCode.shift();
                                 servicesCode.forEach(function(code) {
@@ -290,6 +291,8 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
                 $scope.loaded.get_dataElementsDescriptions = true;
                 $scope.loaded.get_dataElementsGroups = true;
 
+                console.log("searchModule: Data Elements loaded")
+
                 return "done";
 
             }).then(function() {
@@ -319,7 +322,7 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
                             };
 
                             obj.indicatorGroups.forEach(function(grp) {
-                                if(grp.attributeValues.length > 0 && grp.attributeValues[0].value){
+                                if($scope.servicesList && grp.attributeValues.length > 0 && grp.attributeValues[0].value){
                                     var servicesCode = grp.attributeValues[0].value.split('_');
                                     servicesCode.shift();
                                     servicesCode.forEach(function(code) {
@@ -365,6 +368,8 @@ searchModule.controller('searchController', ['ExcelFactory', '$timeout', '$scope
                     $scope.loaded.get_indicatorsDescriptions = true;
                     $scope.loaded.get_indicatorGroups = true;
                     $scope.allObjects = Object.keys(temp).map(function(key) { return temp[key]; });
+
+                    console.log("searchModule: Indicators loaded")
 
                     return "done";
                 });

--- a/app/search/search.view.html
+++ b/app/search/search.view.html
@@ -83,7 +83,7 @@
 										</label>
 									</div>
 								</div>
-								<div class="col-xs-3">
+								<div class="col-xs-3" ng-if="serviceSetUID">
 									<p><b>{{'srch_SelectColumns_servBasics' | translate}}</b></p>
 									<div class="col-xs-1"></div>
 									<div class="col-xs-11">
@@ -118,7 +118,7 @@
 										</label>
 									</div>
 								</div>
-								<div class="col-xs-3">
+								<div class="col-xs-3" ng-if="serviceSetUID">
 									<div class="col-xs-1"></div>
 									<div class="col-xs-11">
 										<label class="checkbox" ng-repeat="col in table.cols" ng-if="cols_service_advanced[col.code]">
@@ -209,7 +209,7 @@
 			<td sortable="'service_code'" filter="{service_code:'./app/search/search.table.html'}" ng-if="false" data-title="'service_code' | translate">
 				<span ng-bind-html='object.service_code | highlight: table.globalSearchTerm:params.filter():"service_code"'></span>
 			</td>
-			<td sortable="'service_name'" filter="{service_name:'./app/search/search.table.html'}" ng-if="true" data-title="'service_name' | translate">
+			<td sortable="'service_name'" filter="{service_name:'./app/search/search.table.html'}" ng-if="serviceSetUID" data-title="'service_name' | translate">
 				<span ng-bind-html='object.service_name | highlight: table.globalSearchTerm:params.filter():"service_name"'></span>
 			</td>
 

--- a/index.html
+++ b/index.html
@@ -131,10 +131,10 @@
 
 			<!-- app: lateral menu -->
 			<ul id="menu-container" class="nav nav-tabs tabs-left sideways" onclick="tabSwitch()" role="tablist" >
-		      	<li id="dossiers" class="active" role="presentation" style="margin-top:48px;"><a href="#dossiers" data-toggle="tab">{{'idx_Dossiers' | translate}}</a></li>
+			  	<li id="search" class="active" role="presentation"><a href="#search" data-toggle="tab" style="margin-top:48px;">{{'idx_Search' | translate}}</a></li>
+		      	<li id="dossiers" ng-if="serviceSetUID" role="presentation"><a href="#dossiers" data-toggle="tab">{{'idx_Dossiers' | translate}}</a></li>
 				<li id="dossierPrograms" role="presentation"><a href="#dossierPrograms" data-toggle="tab">{{'Programs' | translate}}</a></li>
 				<li id="datasets" role="presentation"><a href="#datasets" data-toggle="tab">{{'Data Sets' | translate}}</a></li>
-			  	<li id="search" role="presentation"><a href="#search" data-toggle="tab">{{'idx_Search' | translate}}</a></li>
 				<li id="admin" ng-show="show_admin" role="presentation"><a href="#admin" data-toggle="tab">{{'idx_Admin' | translate}}</a></li>
 		    <!--<li id="graph" role="presentation"><a href="#graph" data-toggle="tab">{{'idx_Graph' | translate}}</a></li> -->
 			 


### PR DESCRIPTION
En el camino hacia que esta app se completamente genérica, con esta PR eliminamos la dependencia con el orgunitGroupSet que nosotros utilizamos para determinar los servicios.

Simplemente en la pantalla Admin hay que dejar en blanco el orgunitgroupset. Si ya está introducido, quizá haya que utilizar el Datastore Manager para eliminarlo.

El módulo search muestra información sobre data elements, indicadores (con fórmula) y permite hacer búsquedas globales y por campo. Cualquier comentario o duda, decidnos.